### PR TITLE
Added TypeKit directories

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import ttfInfo from 'ttfinfo';
 
@@ -109,13 +110,15 @@ const SystemFonts = function(options = {}) {
                 ...directories,
                 path.join(home, 'Library', 'Fonts'),
                 path.join('/', 'Library', 'Fonts'),
-                path.join('/', 'System', 'Library', 'Fonts')
+                path.join('/', 'System', 'Library', 'Fonts'),
+                path.join(os.homedir(), 'Library', 'Application Support', 'Adobe', 'CoreSync', 'plugins', 'livetype', '.r')
             ];
         } else if (platform === 'windows') {
             const winDir = process.env.windir || process.env.WINDIR;
             directories = [
                 ...directories,
-                path.join(winDir, 'Fonts')
+                path.join(winDir, 'Fonts'),
+                path.join(os.homedir(), 'AppData', 'Roaming', 'Adobe', 'CoreSync', 'plugins', 'livetype', 'r')
             ];
         } else { // some flavor of Linux, most likely
             const home = process.env.HOME;


### PR DESCRIPTION
Hi @rBurgett, I am adding extra directories for [Adobe TypeKit](https://typekit.com) fonts for macOS and Windows. Usually design apps like Adobe Photoshop, Figma, or Sketch (via plugin) take these directories into account when searching for "system" fonts, so this library could also benefit from the same location.

Usually TypeKit users do not download fonts and install them system-wide, rather they use TypeKit/CreativeCloud app to keep their fonts "in sync" and they always have them accessible from apps they use.

We can also hide these locations behind a flag/option or make it configurable from caller if you prefer that.