### PR TITLE
Fixed ignored catched directory access errors in recGetFile

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ const recGetFile = (target) => {
             files = fs.readdirSync(target);
         } catch (e) {
             console.error(e);
+            return [];
         }
         return files
             .reduce((arr, f) => {


### PR DESCRIPTION
Having a subdirectory in on of directory paths with missing access rights causes uncaught error:

```
Uncaught TypeError: Cannot read property 'reduce' of undefined
```


In `catch` branch in such case we should return an empty array and stop execution.