### PR TITLE
Add User Local  windows fonts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -149,6 +149,7 @@ const SystemFonts = function(options = {}) {
             directories = [
                 ...directories,
                 path.join(winDir, 'Fonts'),
+                path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'Windows', 'Fonts'),
                 path.join(os.homedir(), 'AppData', 'Roaming', 'Adobe', 'CoreSync', 'plugins', 'livetype', 'r')
             ];
         } else { // some flavor of Linux, most likely


### PR DESCRIPTION
I know that I can use the customDirs to add this folder myself. However, this seems to be a permanent change to where windows install user fonts.

https://blogs.windows.com/windowsexperience/2018/06/27/announcing-windows-10-insider-preview-build-17704/#vtHzS6SkLWyrfI4D.97